### PR TITLE
fix: don't allow animations to stack up

### DIFF
--- a/Amplosion/DogPark.swift
+++ b/Amplosion/DogPark.swift
@@ -318,6 +318,8 @@ class DogPark: UIControl {
     }
     
     func bork() {
+        guard !isPlayingOutUserInteraction else { return }
+
         isPlayingOutUserInteraction = true
         dirtWasSelected = false
         startDirtExpirationCountdown(seconds: 2)


### PR DESCRIPTION
It seems if we don't check the interaction play-out that we can still land ourselves in stacking up actions. This blocks at the bork level.